### PR TITLE
Feat/nav icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,10 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
         "lottie-react": "^2.4.1",
+        "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "react-router-dom": "^7.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -2081,7 +2082,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -3440,6 +3440,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -3922,10 +3930,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
-      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
-      "license": "MIT",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -3944,12 +3951,11 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
-      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
-      "license": "MIT",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
       "dependencies": {
-        "react-router": "7.6.3"
+        "react-router": "7.7.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4082,8 +4088,7 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,10 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
     "lottie-react": "^2.4.1",
+    "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { Home, Search, BookMarked, Library, LibraryBigIcon, BookOpen } from 'lucide-react';
+import { Home, Search, BookMarked, BookOpen } from 'lucide-react';
 
 export default function Navbar() {
   const location = useLocation();

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
+import { Home, Search, BookMarked, Library, LibraryBigIcon, BookOpen } from 'lucide-react';
 
 export default function Navbar() {
   const location = useLocation();
@@ -9,7 +10,7 @@ export default function Navbar() {
       <div className="navbar-container">
         {/* Logo */}
         <Link to="/" className="navbar-logo">
-          <div className="text-2xl">📚</div>
+          <div className="text-2xl"><BookOpen size={35} className="text-[#0f766e]"/></div>
           <div>
             <h1 className="text-xl font-bold" style={{ color: 'var(--primary-700)' }}>Pouranik</h1>
             <p className="text-xs" style={{ color: 'var(--text-muted)', marginTop: '-2px' }}>Book Discovery</p>
@@ -19,9 +20,9 @@ export default function Navbar() {
         {/* Navigation Links */}
         <div className="navbar-menu">
           {[
-            { path: '/', label: 'Home', icon: '🏠' },
-            { path: '/explore', label: 'Explore', icon: '🔍' },
-            { path: '/genres', label: 'Genres', icon: '📑' }
+            { path: '/', label: 'Home', icon: <Home size={18} /> },
+            { path: '/explore', label: 'Explore', icon: <Search size={18} /> },
+            { path: '/genres', label: 'Genres', icon: <BookMarked size={18} /> }
           ].map(({ path, label, icon }) => (
             <Link 
               key={path}


### PR DESCRIPTION
This PR updates the main navigation bar by replacing the existing emoji icons with professional Lucide icons:

- `🏠` → `Home` (Lucide)
- `🔍` → `Search` (Lucide)
- `📑` → `BookMarked`
- `📚` → `BookOpen` (Lucide, with custom teal color `#0f766e`)

This enhances the visual consistency and modern look of the UI. Also added appropriate styling for icon spacing.

Let me know if any changes are needed. Thanks!