### PR TITLE
Website Tour Shows Every Time — Should Only Appear Once (#95)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
     // Check localStorage first, then system preference
     const saved = localStorage.getItem('theme');
     if (saved) return saved === 'dark';
-    
+
     return window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
 
@@ -28,7 +28,7 @@ function App() {
   };
 
   // --- Custom Tour Guide State ---
-   const tourSteps = useMemo(() => [
+  const tourSteps = useMemo(() => [
     {
       selector: "navbar-logo",
       title: "Logo/Home",
@@ -65,7 +65,7 @@ function App() {
       content: "See books by genre.",
     },
   ], []);
-  
+
   const [tourStep, setTourStep] = useState(0);
   const [tourOpen, setTourOpen] = useState(false);
 
@@ -83,13 +83,20 @@ function App() {
   }, [tourStep, tourOpen, tourSteps]);
 
   useEffect(() => {
-    // Show tour on every refresh
-    setTimeout(() => setTourOpen(true), 800); // slight delay for UI mount
+
+    // Show tour only once for each user.
+    if (!localStorage.getItem("isOldUser")) {
+      setTimeout(() => setTourOpen(true), 800); // slight delay for UI mount
+    }
   }, []);
 
   const handleTourNext = () => setTourStep((s) => Math.min(s + 1, tourSteps.length - 1));
   const handleTourPrev = () => setTourStep((s) => Math.max(s - 1, 0));
-  const handleTourClose = () => setTourOpen(false);
+  const handleTourClose = () => {
+    setTourOpen(false);
+    // set the localstorage variable that tour is done
+    localStorage.setItem("isOldUser", "true")
+  }
 
   return (
     <div className="app-gradient">


### PR DESCRIPTION
Hi team 👋

This PR resolves issue **#95** where the **website tour was being shown on every visit**, even for returning users.

---

### 🔧 What’s Fixed:

- Implemented `localStorage` check to **detect if the user has already seen the tour**.
- If the tour has been shown once, it **won’t display again on future visits**.

---

### 💡 Outcome:

* First-time users will still see the tour as expected ✅
* Returning users now **skip the repetitive guide**, improving overall UX ✅

