### PR TITLE
fix: input field text not visible in dark theme

### DIFF
--- a/frontend/src/components/AuthForm.jsx
+++ b/frontend/src/components/AuthForm.jsx
@@ -55,7 +55,7 @@ const AuthForm = ({ formType, isDarkMode }) => {
     const inputClasses = `w-full px-6 py-2 rounded-lg text-lg transition-all duration-300 ${
         isDarkMode 
         ? 'bg-gray-800 text-white border-2 border-gray-700 placeholder-gray-400 focus:ring-2 focus:ring-purple-500 focus:border-purple-500'
-        : 'bg-white text-gray-900 border-2 border-gray-200 placeholder-gray-500 focus:ring-2 focus:ring-teal-500 focus:border-teal-500'
+        : 'bg-white !text-gray-900 border-2 border-gray-200 placeholder-gray-500 focus:ring-2 focus:ring-teal-500 focus:border-teal-500'
     }`;
 
     const labelClasses = `text-lg mb-3 font-semibold ${


### PR DESCRIPTION
Resolved an issue where input text in dark mode blended with the background
due to a CSS color override

Screenshots: 
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/d9e7e5bb-96b5-44b5-85f1-56ff5c7fa570" />

<img width="1919" height="860" alt="image" src="https://github.com/user-attachments/assets/bd571532-a762-4363-bc21-0311e8d8b0ed" />

#144 
