### PR TITLE
Increase size of social media icons in Footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -121,7 +121,7 @@ const Footer = ({ isDarkMode }) => {
                   rel="noopener noreferrer"
                   className={`!text-gray-500 transition-colors duration-200 ${social.color}`}
                 >
-                  <social.icon className="w-6 h-6" />
+                  <social.icon className="w-8 h-8" />
                 </a>
               ))}
             </div>
@@ -165,3 +165,4 @@ const Footer = ({ isDarkMode }) => {
 };
 
 export default Footer;
+


### PR DESCRIPTION

The GitHub and Mail icons in the footer were appearing too small compared to the overall layout. Their size has been increased to improve visibility and maintain a balanced UI. This ensures better accessibility and a cleaner visual hierarchy.

This closes the issue #180 