### PR TITLE
Fix footer quick links and popular categories hover text color for light and dark modes

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -133,17 +133,16 @@ const Footer = ({ isDarkMode }) => {
                 {section.title}
               </h3>
               <ul className="space-y-3">
-                {section.links.map((link) => (
-                  <li key={link.name}>
-                    <Link
-                      to={link.href}
-                      className="!text-gray-600 w-fit hover:!text-gray-900 transition-colors duration-200 flex items-center gap-2 group"
-                    >
-                      <link.icon className={`w-4 h-4 ${link.color}`} />
-                      <span>{link.name}</span>
-                    </Link>
-                  </li>
-                ))}
+              {section.links.map((link) => ( 
+                <li key={link.name}>
+                  <Link
+                    to={link.href}
+                    className=" text-black-200 dark:text-white hover:!text-emerald-600 no-underline w-fit transition-colors duration-200 flex items-center gap-2 group  ">
+                    <link.icon className={`w-4 h-4 ${link.color}`} />
+                    <span>{link.name}</span>
+                  </Link>
+                </li>
+              ))}
               </ul>
             </div>
           ))}


### PR DESCRIPTION
#171 
In the footer section under Quick Links, the "Popular Categories" link text disappears on hover when the site is in dark mode due to insufficient contrast.

Screenshots:
<img width="1873" height="378" alt="Screenshot 2025-08-19 194100" src="https://github.com/user-attachments/assets/171d2398-c1a2-4bd0-947c-786dc4f0c4e2" />

<img width="1867" height="320" alt="Screenshot 2025-08-19 194130" src="https://github.com/user-attachments/assets/9d60987a-b13b-48a4-b538-e1438c95bf49" />
