### PR TITLE
Added Social's -linkedin in footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -34,6 +34,13 @@ const Footer = ({ isDarkMode }) => {
       icon: Github,
       color: "!hover:text-gray-800",
     },
+    {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/in/bhakti-more-01a619208/",
+    icon: Linkedin, 
+    color: "!hover:text-blue-700",
+  },
+
   ];
 
   const footerLinks = [
@@ -165,3 +172,4 @@ const Footer = ({ isDarkMode }) => {
 };
 
 export default Footer;
+


### PR DESCRIPTION
## 🐞 Issue: Add LinkedIn Link to Footer

Add a LinkedIn icon/link alongside the existing social icons in the footer. 

- [x] Match the current theme (dark mode styling)
- [x] Be consistent in size and spacing with the other icons
- [x] Link to the appropriate LinkedIn profile or organization pag

fixes : #183

Before :
<img width="614" height="284" alt="Screenshot 2025-08-19 232010" src="https://github.com/user-attachments/assets/49a57c9f-03e8-4502-b31f-1742118dc6fb" />
After :
<img width="617" height="307" alt="Screenshot 2025-08-19 230624" src="https://github.com/user-attachments/assets/5e4ac730-33c9-496e-8781-483734115297" />
