### PR TITLE
Sign Up/Sign In Theme Optimization for dark mode

### DIFF
--- a/frontend/src/components/AuthForm.jsx
+++ b/frontend/src/components/AuthForm.jsx
@@ -73,7 +73,7 @@ const AuthForm = ({ formType, isDarkMode }) => {
             <div className={`w-100  max-w-2xl mx-auto login-card rounded-2xl shadow-2xl p-8 ${
                 isDarkMode 
                 ? 'border border-gray-700 bg-gray-800/40'
-                : 'border border-gray-200 bg-white/40'
+                : 'border border-gray-200 bg-grey/40'
             }`}>
                 <h1 className={`!text-xl font-bold text-center mb-5 tracking-wide ${
                     isDarkMode ? 'text-white shimmer' : 'text-gray-800'


### PR DESCRIPTION
Fixes #184 

## Pull Request Summary
This PR improves the Sign Up/Sign In pages by optimizing the theme compatibility for dark mode.

## Problem
In dark mode, the Sign Up/Sign In forms did not match the overall theme.

Before:
<img width="1920" height="829" alt="Screenshot (104)" src="https://github.com/user-attachments/assets/96978cc6-c77e-4976-a751-d7326017af59" />
<img width="1627" height="815" alt="Screenshot (106)" src="https://github.com/user-attachments/assets/cf6973ff-9a75-4e8b-9c97-a5bd82833897" />

After:
<img width="1920" height="820" alt="Screenshot (107)" src="https://github.com/user-attachments/assets/87838274-decd-47d6-86fb-6cd55808582d" />
<img width="1920" height="848" alt="Screenshot (108)" src="https://github.com/user-attachments/assets/86a410c5-82fb-41d1-99b6-4d155a0a9459" />
