### PR TITLE
Fixes #209: Add count-up animation to stats section

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "@tailwindcss/vite": "^4.1.11",
+        "countup": "^1.8.2",
+        "countup.js": "^2.9.0",
         "date-fns": "^4.1.0",
         "internmap": "^2.0.3",
         "jwt-decode": "^4.0.0",
@@ -2683,6 +2685,17 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/countup": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/countup/-/countup-1.8.2.tgz",
+      "integrity": "sha512-1qOuy+h+dgLY4TroLb4ZC2hK7HYS2Z7mnSUvdzoYAU7EZbqOse1mKZta/KYPhDPfd9lPDyP3Tb4pH6a10RkoCw=="
+    },
+    "node_modules/countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
+      "license": "MIT"
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "@tailwindcss/vite": "^4.1.11",
+    "countup": "^1.8.2",
+    "countup.js": "^2.9.0",
     "date-fns": "^4.1.0",
     "internmap": "^2.0.3",
     "jwt-decode": "^4.0.0",

--- a/frontend/src/pages/Genres.jsx
+++ b/frontend/src/pages/Genres.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import "./Genres.css";
+import { CountUp } from "countup.js";
 
 const genres = [
   {
@@ -136,7 +137,7 @@ const booksCover = [
 
 export default function Genres() {
   const observerRef = useRef(null);
-
+  const miniAnimatedRef = useRef(false);
   // Scroll reveal animation effect
   useEffect(() => {
     const observerCallback = (entries) => {
@@ -145,6 +146,39 @@ export default function Genres() {
           entry.target.classList.add("animate-reveal");
         }
       });
+    
+        const section = document.getElementById("mini-stats");
+        if (!section) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting && !miniAnimatedRef.current) {
+            miniAnimatedRef.current = true;
+
+            // Animate Books: 1 → 40 with M+
+            new CountUp("mini-books-count", 40, {
+              duration: 2,
+            }).start();
+
+            // Animate Genres: 1 → 12
+            new CountUp("mini-genres-count", 12, {
+              duration: 2,
+            }).start();
+
+            // Animate Languages: 1 → 100 with +
+            new CountUp("mini-languages-count", 100, {
+              duration: 2,
+            }).start();
+
+            observer.disconnect();
+          }
+        },
+        { threshold: 0.3 }
+      );
+
+      observer.observe(section);
+
+      return () => observer.disconnect();
     };
 
     observerRef.current = new IntersectionObserver(observerCallback, {
@@ -228,47 +262,29 @@ export default function Genres() {
           </p>
 
           {/* Stats */}
-          <div className="glass-effect card-small max-w-2xl mx-auto border-subtle">
+          <div className="glass-effect card-small max-w-2xl mx-auto border-subtle" id="mini-stats">
             <div className="grid grid-cols-3 gap-6 text-center">
               <div>
-                <div
-                  className="text-2xl font-bold"
-                  style={{ color: "var(--primary-600)" }}
-                >
-                  40M+
+                <div className="text-2xl font-bold" style={{ color: "var(--primary-600)" }}>
+                  <span id="mini-books-count">0</span>M+
                 </div>
-                <div
-                  className="text-small"
-                  style={{ color: "var(--text-muted)" }}
-                >
+                <div className="text-small" style={{ color: "var(--text-muted)" }}>
                   Total Books
                 </div>
               </div>
               <div>
-                <div
-                  className="text-2xl font-bold"
-                  style={{ color: "var(--primary-600)" }}
-                >
-                  12
+                <div className="text-2xl font-bold" style={{ color: "var(--primary-600)" }}>
+                  <span id="mini-genres-count">0</span>
                 </div>
-                <div
-                  className="text-small"
-                  style={{ color: "var(--text-muted)" }}
-                >
+                <div className="text-small" style={{ color: "var(--text-muted)" }}>
                   Popular Genres
                 </div>
               </div>
               <div>
-                <div
-                  className="text-2xl font-bold"
-                  style={{ color: "var(--primary-600)" }}
-                >
-                  100+
+                <div className="text-2xl font-bold" style={{ color: "var(--primary-600)" }}>
+                  <span id="mini-languages-count">0</span>+
                 </div>
-                <div
-                  className="text-small"
-                  style={{ color: "var(--text-muted)" }}
-                >
+                <div className="text-small" style={{ color: "var(--text-muted)" }}>
                   Languages
                 </div>
               </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -6,6 +6,8 @@ import { LiaBookSolid } from "react-icons/lia";
 import { TbCategory } from "react-icons/tb";
 import { GiInspiration } from "react-icons/gi";
 import { TbTargetArrow } from "react-icons/tb";
+import { CountUp } from "countup.js";
+
 
 export default function Home() {
   const observerRef = useRef(null);
@@ -35,6 +37,7 @@ export default function Home() {
   }
 }, []);
 
+const animatedRef = useRef(false);
   // Scroll reveal animation effect
   useEffect(() => {
     const observerCallback = (entries) => {
@@ -43,6 +46,34 @@ export default function Home() {
           entry.target.classList.add('animate-reveal');
         }
       });
+
+      // Animate stats numbers when stats section comes into view
+        const section = document.getElementById("stats-section");
+        if (!section) return;
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            if (entries[0].isIntersecting && !animatedRef.current) {
+              animatedRef.current = true; 
+
+              new CountUp("books-count", 40, {
+                duration: 2,
+              }).start();
+
+              new CountUp("languages-count", 100, {
+                duration: 2,
+              }).start();
+
+              observer.disconnect(); 
+            }
+          },
+          { threshold: 0.3 }
+        );
+
+        observer.observe(section);
+
+        return () => observer.disconnect();
+
     };
 
     observerRef.current = new IntersectionObserver(observerCallback, {
@@ -318,22 +349,27 @@ export default function Home() {
       </section>
 
       {/* Stats Section */}
-      <section className="section-padding-sm scroll-reveal delay-200">
+      <section className="section-padding-sm scroll-reveal delay-200" id="stats-section">
         <div className="container-md">
-          <div className="card-modern text-center" data-tour="powered-by-google-books-section">
+          <div
+            className="card-modern text-center"
+            data-tour="powered-by-google-books-section"
+          >
             <h3
               className="text-2xl font-semibold mb-8"
               style={{ color: "var(--primary-700)" }}
             >
               Powered by Google Books
             </h3>
+
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              {/* Books Available */}
               <div className="text-center">
                 <div
                   className="text-5xl font-bold mb-2"
                   style={{ color: "var(--accent-orange)" }}
                 >
-                  40M+
+                  <span id="books-count">0</span>M+
                 </div>
                 <div
                   className="text-lg"
@@ -342,12 +378,14 @@ export default function Home() {
                   Books Available
                 </div>
               </div>
+
+              {/* Languages */}
               <div className="text-center">
                 <div
                   className="text-5xl font-bold mb-2"
                   style={{ color: "var(--accent-orange)" }}
                 >
-                  100+
+                  <span id="languages-count">0</span>+
                 </div>
                 <div
                   className="text-lg"
@@ -356,9 +394,11 @@ export default function Home() {
                   Languages
                 </div>
               </div>
+
+              {/* Possibilities */}
               <div className="text-center">
                 <div
-                  className="text-5xl font-bold mb-2"
+                  className="text-5xl font-bold mb-2 animate-pulse"
                   style={{ color: "var(--accent-orange)" }}
                 >
                   ∞


### PR DESCRIPTION
## Which issue does this PR close?

Fixes #209 : Implement count-up animations for stats sections

- Closes #209 

## Rationale for this change

Currently, the stats for books, genres, and languages are shown as static text. Adding a smooth count-up animation makes the section more dynamic, improves visual appeal, and gives users a stronger sense of growth and scale. This change is mainly a UI/UX enhancement that aligns with modern interaction patterns.

## What changes are included in this PR?

- Integrated CountUp.js to animate numbers.
- Applied the count-up effect to the main stats (Books, Genres, Languages).
- Ensured the animation only triggers once using IntersectionObserver.
- Updated both the hero stats card and the mini-stats card for consistency.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

Yes:
1. Users will now see a count-up animation instead of static numbers.
2. Improves overall interactivity and perceived responsiveness of the site.


Following is the demonstration-

https://github.com/user-attachments/assets/afe41399-eb13-4d93-8b44-4f1ae358e2e9
