### PR TITLE
Fix: Book Icon Disappears in Light Mode on Explore Page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -437,6 +437,23 @@ body {
         inset 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+span.input-icon {
+  position: absolute;
+  top: 50%;
+  left: 24px;
+  transform: translateY(-50%);
+  font-size: 1.5rem; 
+  color: teal; 
+  pointer-events: none;
+  transition: color 0.3s ease;
+  z-index: 10;
+}
+
+.dark span.input-icon {
+  color: #5eead4; 
+}
+
+
 .search-glow:focus {
     box-shadow:
         0 0 32px rgba(139, 69, 19, 0.3),

--- a/frontend/src/pages/Explore.jsx
+++ b/frontend/src/pages/Explore.jsx
@@ -425,12 +425,12 @@ const popularSearches = searchType === 'books' ? popularBookSearches : famousAut
                   onChange={handleInputChange}
                   autoComplete="off"
                 />
-                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 text-2xl pointer-events-none">
-                  {searchType === 'books' ? <FaBookOpen /> : <FaPen />}
+                <span className="input-icon">
+                  {searchType === "books" ? <FaBookOpen /> : <FaPen />}
                 </span>
+
               </div>
-              
-              {/* Autocomplete Dropdown */}
+{/* Autocomplete Dropdown */}
               <div className="w-full max-w-2xl mx-auto dropdown-container">
                 <SearchAutocomplete
                   suggestions={suggestions}
@@ -706,3 +706,5 @@ const popularSearches = searchType === 'books' ? popularBookSearches : famousAut
       </div>
   );
 }
+
+              


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #232

## Rationale for this change
Switching from dark mode to light mode on the Explore page caused the book icon above the search bar to disappear. This fix ensures the icon remains visible in both modes.

## What changes are included in this PR?
- Updated the styling/CSS of the book icon container to make it visible in light mode.
- Verified that the icon displays correctly in both dark and light modes.

## Are these changes tested?
Yes, tested manually by toggling between dark mode and light mode on the Explore page.

## Are there any user-facing changes?
Yes, the book icon remains visible in light mode for users.
